### PR TITLE
tar xz compression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,8 @@ jobs:
         cd vdb_data
         tar -cvzf data.vdb5.tar.gz data.vdb5
         tar -cvzf data.index.vdb5.tar.gz data.index.vdb5
+        tar -cvJf data.vdb5.tar.xz data.vdb5
+        tar -cvJf data.index.vdb5.tar.xz data.index.vdb5
         echo $GITHUB_TOKEN | oras login ghcr.io -u $GITHUB_USERNAME --password-stdin
         oras push ghcr.io/$IMAGE_NAME:v5 \
           --config ../config.json:application/vnd.oras.config.v1+json \
@@ -61,6 +63,10 @@ jobs:
           --artifact-type application/vnd.oras.config.v1+json \
           ./data.vdb5.tar.gz:application/vnd.appthreat.vdb.layer.v1+tar \
           ./data.index.vdb5.tar.gz:application/vnd.appthreat.vdb.layer.v1+tar
+        oras push ghcr.io/appthreat/vdbxz:v5 \
+          --artifact-type application/vnd.oras.config.v1+json \
+          ./data.vdb5.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
+          ./data.index.vdb5.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
         cd ..
         nydus-image create -t dir-rafs --blob-id appthreat-vdb-v5 --blob rafs_out/data.rafs --bootstrap rafs_out/meta.rafs vdb_data --repeatable
         cd rafs_out
@@ -96,6 +102,8 @@ jobs:
         cd vdb_data
         tar -cvzf data.vdb5.tar.gz data.vdb5
         tar -cvzf data.index.vdb5.tar.gz data.index.vdb5
+        tar -cvJf data.vdb5.tar.xz data.vdb5
+        tar -cvJf data.index.vdb5.tar.xz data.index.vdb5
         echo $GITHUB_TOKEN | oras login ghcr.io -u $GITHUB_USERNAME --password-stdin
         oras push ghcr.io/appthreat/vdb-10y:v5 \
           --artifact-type application/vnd.oras.config.v1+json \
@@ -105,6 +113,10 @@ jobs:
           --artifact-type application/vnd.oras.config.v1+json \
           ./data.vdb5.tar.gz:application/vnd.appthreat.vdb.layer.v1+tar \
           ./data.index.vdb5.tar.gz:application/vnd.appthreat.vdb.layer.v1+tar
+        oras push ghcr.io/appthreat/vdbxz-10y:v5 \
+          --artifact-type application/vnd.oras.config.v1+json \
+          ./data.vdb5.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
+          ./data.index.vdb5.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
         cd ..
         nydus-image create -t dir-rafs --blob-id appthreat-vdb-10y-v5 --blob rafs_out/data.rafs --bootstrap rafs_out/meta.rafs vdb_data --repeatable
         cd rafs_out


### PR DESCRIPTION
xz is beating gzip on compression

14808348 vs 26278705
69472440 vs 154205783

https://github.com/AppThreat/vdb/pkgs/container/vdbgz/177041731?tag=v5

```json
{
      "digest": "sha256:32bd84f9e91a983133235f705b47fb6cd3e025ddb7e2e6d28eaa6e0bb660e71b",
      "mediaType": "application/vnd.appthreat.vdb.layer.v1+tar",
      "size": 26278705
    },
    {
      "digest": "sha256:261cbf8e0ec4d1b63bdab41e07887c82336426474ccc404bc890708510b0e61b",
      "mediaType": "application/vnd.appthreat.vdb.layer.v1+tar",
      "size": 154205783
    }
```

https://github.com/AppThreat/vdb/pkgs/container/vdbxz/177041765?tag=v5

```json
{
      "digest": "sha256:a0d7e85e404392d36f284913d868d9f6492be8c561290df333bd96c21f9f0505",
      "mediaType": "application/vnd.appthreat.vdb.layer.v1+tar",
      "size": 14808348
    },
    {
      "digest": "sha256:7ce8506ec0ab9ebb170f20924de42325eff33bc29f8709237813f3c7faf9fca9",
      "mediaType": "application/vnd.appthreat.vdb.layer.v1+tar",
      "size": 69472440
    }
```

Perhaps we use xz as the default in depscan v6 since the decompression is likely to take more time and memory?

cc: @heubeck