### PR TITLE
Fix: remove double actions/checkout@v4

### DIFF
--- a/.github/workflows/build-app-only.yml
+++ b/.github/workflows/build-app-only.yml
@@ -16,7 +16,6 @@ jobs:
       packages: write
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/checkout@v4
       with:
         repository: AppThreat/vulnerability-db
         path: vulnerability-db

--- a/.github/workflows/build-vdb6.yml
+++ b/.github/workflows/build-vdb6.yml
@@ -16,7 +16,6 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
         with:
           repository: AppThreat/vulnerability-db
           path: vulnerability-db

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
       packages: write
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/checkout@v4
       with:
         repository: AppThreat/vulnerability-db
         path: vulnerability-db


### PR DESCRIPTION
I noticed that `- uses: actions/checkout@v4` has been copied twice in github workflow actions. This PR removes one of them.