### PR TITLE
refactor: DRY up build-vdb65 workflow with composite actions

### DIFF
--- a/.github/actions/build-upload-vdb/action.yml
+++ b/.github/actions/build-upload-vdb/action.yml
@@ -1,0 +1,95 @@
+name: 'Build and Upload VDB'
+description: 'Build VDB database, compress, and upload to GHCR and HuggingFace'
+
+inputs:
+  xz-image-name:
+    description: 'ORAS image name for xz compressed artifacts'
+    required: true
+  zst-image-name:
+    description: 'ORAS image name for zstd compressed artifacts'
+    required: true
+  hf-path:
+    description: 'HuggingFace dataset upload path prefix'
+    required: true
+  vuln-list-path:
+    description: 'Path to the vuln-list directory'
+    required: false
+    default: 'vuln-list'
+  self-hosted:
+    description: 'Whether running on a self-hosted runner'
+    required: false
+    default: 'false'
+  os-exclude-dirs:
+    description: 'Directories to exclude from vuln-list before build'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+
+  steps:
+    - name: Build and upload VDB
+      shell: bash
+      run: |
+        echo $GITHUB_TOKEN | oras login ghcr.io -u $GITHUB_USERNAME --password-stdin
+        mkdir vdb_data vdb_cache
+
+        VULN_DIR="${{ inputs.vuln-list-path }}"
+
+        # Exclude unnecessary dirs for OS builds
+        if [ -n "${{ inputs.os-exclude-dirs }}" ]; then
+          for dir in ${{ inputs.os-exclude-dirs }}; do
+            rm -rf "${VULN_DIR}/${dir}"
+          done
+        fi
+
+        ls ${VULN_DIR}/ ${VULN_DIR}/nvd/
+        zip -q -r vuln-list.zip ${VULN_DIR}/
+        mv vuln-list.zip vdb_cache/
+        rm -rf ${VULN_DIR}/
+
+        PYTHON_CMD="python"
+        if [ "${{ inputs.self-hosted }}" = "true" ]; then
+          PYTHON_CMD="python3"
+        fi
+
+        ${PYTHON_CMD} vulnerability-db/vdb/cli.py --cache-os
+        ls -lh vdb_data
+        ls -lh vdb_cache
+        cd vdb_data
+
+        tar -cvJf data.vdb6.tar.xz data.vdb6
+        tar -cvJf data.index.vdb6.tar.xz data.index.vdb6
+
+        oras push ghcr.io/appthreat/${{ inputs.xz-image-name }}:v6.5.x \
+          --artifact-type application/vnd.oras.config.v1+json \
+          ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
+          ./data.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
+          ./data.index.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
+        oras tag ghcr.io/appthreat/${{ inputs.xz-image-name }}:v6.5.x v6
+
+        hf upload --quiet --repo-type dataset --delete ${{ inputs.hf-path }}/*.tar.xz AppThreat/vdb ./data.vdb6.tar.xz ${{ inputs.hf-path }}/data.vdb6.tar.xz
+        hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6.tar.xz ${{ inputs.hf-path }}/data.index.vdb6.tar.xz
+
+        zstd --ultra data.index.vdb6
+        zstd --ultra data.vdb6
+
+        oras push ghcr.io/appthreat/${{ inputs.zst-image-name }}:v6.5.x \
+          --artifact-type application/vnd.oras.config.v1+json \
+          ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
+          ./data.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst \
+          ./data.index.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst
+        oras tag ghcr.io/appthreat/${{ inputs.zst-image-name }}:v6.5.x v6
+
+        hf upload --quiet --repo-type dataset --delete ${{ inputs.hf-path }}/*.zst AppThreat/vdb ./data.vdb6.zst ${{ inputs.hf-path }}/data.vdb6.zst
+        hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6.zst ${{ inputs.hf-path }}/data.index.vdb6.zst
+        hf upload --quiet --repo-type dataset --delete ${{ inputs.hf-path }}/*.vdb6 AppThreat/vdb ./data.vdb6 ${{ inputs.hf-path }}/data.vdb6
+        hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6 ${{ inputs.hf-path }}/data.index.vdb6
+        hf upload --quiet --repo-type dataset AppThreat/vdb ./vdb.meta ${{ inputs.hf-path }}/vdb.meta
+      env:
+        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        PYTHONPATH: vulnerability-db
+        VDB_HOME: vdb_data
+        VDB_CACHE: vdb_cache
+        GITHUB_USERNAME: ${{ env.GITHUB_USERNAME }}
+        HF_TOKEN: ${{ env.HF_TOKEN }}

--- a/.github/actions/build-upload-vdb/action.yml
+++ b/.github/actions/build-upload-vdb/action.yml
@@ -11,6 +11,17 @@ inputs:
   hf-path:
     description: 'HuggingFace dataset upload path prefix'
     required: true
+  hf-token:
+    description: 'HuggingFace token for uploads'
+    required: true
+  github-token:
+    description: 'GitHub token for ORAS login'
+    required: false
+    default: ${{ github.token }}
+  github-username:
+    description: 'GitHub username for ORAS login'
+    required: false
+    default: ${{ github.actor }}
   vuln-list-path:
     description: 'Path to the vuln-list directory'
     required: false
@@ -32,7 +43,7 @@ runs:
       shell: bash
       run: |
         echo $GITHUB_TOKEN | oras login ghcr.io -u $GITHUB_USERNAME --password-stdin
-        mkdir vdb_data vdb_cache
+        mkdir -p vdb_data vdb_cache
 
         VULN_DIR="${{ inputs.vuln-list-path }}"
 
@@ -87,9 +98,9 @@ runs:
         hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6 ${{ inputs.hf-path }}/data.index.vdb6
         hf upload --quiet --repo-type dataset AppThreat/vdb ./vdb.meta ${{ inputs.hf-path }}/vdb.meta
       env:
-        GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
         PYTHONPATH: vulnerability-db
         VDB_HOME: vdb_data
         VDB_CACHE: vdb_cache
-        GITHUB_USERNAME: ${{ env.GITHUB_USERNAME }}
-        HF_TOKEN: ${{ env.HF_TOKEN }}
+        GITHUB_USERNAME: ${{ inputs.github-username }}
+        HF_TOKEN: ${{ inputs.hf-token }}

--- a/.github/actions/setup-vdb/action.yml
+++ b/.github/actions/setup-vdb/action.yml
@@ -1,0 +1,87 @@
+name: 'Setup VDB Build Environment'
+description: 'Checkout repos, install tools and dependencies for VDB build'
+
+inputs:
+  nvd-years:
+    description: 'Comma-separated NVD years for sparse checkout (e.g. "2024,2025,2026")'
+    required: true
+  sparse-checkout:
+    description: 'Whether to use sparse checkout for vuln-list'
+    required: false
+    default: 'true'
+  self-hosted:
+    description: 'Whether running on a self-hosted runner'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+
+  steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
+
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        repository: AppThreat/vulnerability-db
+        path: vulnerability-db
+        ref: 'master'
+        persist-credentials: false
+
+    - name: Checkout vuln-list with sparse checkout
+      if: inputs.sparse-checkout == 'true'
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        repository: AppThreat/vuln-list
+        path: vuln-list
+        fetch-depth: '1'
+        sparse-checkout: ${{ inputs.nvd-years }}
+        persist-credentials: false
+
+    - name: Checkout vuln-list full
+      if: inputs.sparse-checkout != 'true'
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        repository: AppThreat/vuln-list
+        path: vuln-list
+        fetch-depth: '1'
+        persist-credentials: false
+
+    - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
+
+    - name: Set up Python
+      if: inputs.self-hosted != 'true'
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      with:
+        python-version: '3.12'
+
+    - name: Trim CI agent
+      if: inputs.self-hosted != 'true'
+      shell: bash
+      run: |
+        chmod +x contrib/free_disk_space.sh
+        ./contrib/free_disk_space.sh
+
+    - name: Install dependencies
+      if: inputs.self-hosted != 'true'
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine build
+        curl -LsSf https://hf.co/cli/install.sh | bash
+        hf --help
+        cd vulnerability-db && pip install -U ".[dev]"
+      env:
+        HF_TOKEN: ${{ env.HF_TOKEN }}
+
+    - name: Install dependencies (self-hosted)
+      if: inputs.self-hosted == 'true'
+      shell: bash
+      run: |
+        python3 -m pip config set global.break-system-packages true
+        curl -LsSf https://hf.co/cli/install.sh | bash
+        hf --help
+        cd vulnerability-db && python3 -m pip install -U ".[dev]" --no-warn-script-location
+      env:
+        HF_TOKEN: ${{ env.HF_TOKEN }}

--- a/.github/actions/setup-vdb/action.yml
+++ b/.github/actions/setup-vdb/action.yml
@@ -3,8 +3,9 @@ description: 'Checkout repos, install tools and dependencies for VDB build'
 
 inputs:
   nvd-years:
-    description: 'Comma-separated NVD years for sparse checkout (e.g. "2024,2025,2026")'
-    required: true
+    description: 'Newline-separated sparse-checkout patterns for NVD data (e.g. "nvd/2024\nnvd/2025\nnvd/2026")'
+    required: false
+    default: ''
   sparse-checkout:
     description: 'Whether to use sparse checkout for vuln-list'
     required: false
@@ -29,8 +30,13 @@ runs:
         ref: 'master'
         persist-credentials: false
 
+    - name: Validate nvd-years for sparse checkout
+      if: inputs.sparse-checkout == 'true' && inputs.nvd-years == ''
+      shell: bash
+      run: echo "::error::nvd-years input is required when sparse-checkout is enabled" && exit 1
+
     - name: Checkout vuln-list with sparse checkout
-      if: inputs.sparse-checkout == 'true'
+      if: inputs.sparse-checkout == 'true' && inputs.nvd-years != ''
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         repository: AppThreat/vuln-list

--- a/.github/workflows/build-vdb65.yml
+++ b/.github/workflows/build-vdb65.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "20 */12 * * *"
   workflow_dispatch:
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: appthreat/vdb
@@ -14,107 +15,24 @@ jobs:
     permissions:
       contents: write
       packages: write
+    env:
+      GITHUB_PAGE_COUNT: 10
+      NVD_START_YEAR: 2024
+      VDB_IGNORE_OS: true
+      VDB_METADATA_APP_ONLY: true
+      VDB_IGNORE_ALMALINUX: true
+      VDB_IGNORE_ALPINE: true
+      VDB_IGNORE_DEBIAN: true
+      VDB_IGNORE_ROCKYLINUX: true
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: ./.github/actions/setup-vdb
         with:
-          persist-credentials: false
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+          nvd-years: "nvd/2024\nnvd/2025\nnvd/2026"
+      - uses: ./.github/actions/build-upload-vdb
         with:
-          repository: AppThreat/vulnerability-db
-          path: vulnerability-db
-          ref: "master"
-          persist-credentials: false
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: AppThreat/vuln-list
-          path: vuln-list
-          fetch-depth: "1"
-          sparse-checkout: |
-            nvd/2024
-            nvd/2025
-            nvd/2026
-          persist-credentials: false
-      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Trim CI agent
-        run: |
-          chmod +x contrib/free_disk_space.sh
-          ./contrib/free_disk_space.sh
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine build
-          curl -LsSf https://hf.co/cli/install.sh | bash
-          hf --help
-          cd vulnerability-db && pip install -U ".[dev]"
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      - name: Build and upload app db - 2024
-        run: |
-          echo $GITHUB_TOKEN | oras login ghcr.io -u $GITHUB_USERNAME --password-stdin
-          mkdir vdb_data vdb_cache
-          ls ./vuln-list/ ./vuln-list/nvd/
-          zip -q -r vuln-list.zip ./vuln-list/
-          mv vuln-list.zip vdb_cache/
-          rm -rf ./vuln-list/
-          python vulnerability-db/vdb/cli.py --cache-os
-          ls -lh vdb_data
-          ls -lh vdb_cache
-          cd vdb_data
-          tar -cvJf data.vdb6.tar.xz data.vdb6
-          tar -cvJf data.index.vdb6.tar.xz data.index.vdb6
-          oras push ghcr.io/appthreat/vdbxz-app-2y:v6.5.x \
-            --artifact-type application/vnd.oras.config.v1+json \
-            ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-            ./data.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
-            ./data.index.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
-          oras tag ghcr.io/appthreat/vdbxz-app-2y:v6.5.x v6
-          hf upload --quiet --repo-type dataset --delete app-2y/*.tar.xz AppThreat/vdb ./data.vdb6.tar.xz app-2y/data.vdb6.tar.xz
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6.tar.xz app-2y/data.index.vdb6.tar.xz
-          zstd --ultra data.index.vdb6
-          zstd --ultra data.vdb6
-          oras push ghcr.io/appthreat/vdbzst-app-2y:v6.5.x \
-            --artifact-type application/vnd.oras.config.v1+json \
-            ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-            ./data.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst \
-            ./data.index.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst
-          oras tag ghcr.io/appthreat/vdbzst-app-2y:v6.5.x v6
-          hf upload --quiet --repo-type dataset --delete app-2y/*.zst AppThreat/vdb ./data.vdb6.zst app-2y/data.vdb6.zst
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6.zst app-2y/data.index.vdb6.zst
-          hf upload --quiet --repo-type dataset --delete app-2y/*.vdb6 AppThreat/vdb ./data.vdb6 app-2y/data.vdb6
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6 app-2y/data.index.vdb6
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./vdb.meta app-2y/vdb.meta
-          # echo $CODEBERG_TOKEN | oras login codeberg.org -u $CODEBERG_USERNAME --password-stdin
-          # oras push codeberg.org/appthreat/vdbzst-app-2y:v6.5.x \
-          #   --artifact-type application/vnd.oras.config.v1+json \
-          #   ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-          #   ./data.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst \
-          #   ./data.index.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst
-          # oras push codeberg.org/appthreat/vdbxz-app-2y:v6.5.x \
-          #   --artifact-type application/vnd.oras.config.v1+json \
-          #   ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-          #   ./data.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
-          #   ./data.index.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODEBERG_TOKEN: ${{ secrets.CODEBERG_DEPLOY }}
-          PYTHONPATH: vulnerability-db
-          VDB_HOME: vdb_data
-          VDB_CACHE: vdb_cache
-          GITHUB_PAGE_COUNT: 10
-          NVD_START_YEAR: 2024
-          GITHUB_USERNAME: ${{ github.actor }}
-          CODEBERG_USERNAME: appthreat
-          VDB_IGNORE_OS: true
-          VDB_METADATA_APP_ONLY: true
-          VDB_IGNORE_ALMALINUX: true
-          VDB_IGNORE_ALPINE: true
-          VDB_IGNORE_DEBIAN: true
-          VDB_IGNORE_ROCKYLINUX: true
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          xz-image-name: vdbxz-app-2y
+          zst-image-name: vdbzst-app-2y
+          hf-path: app-2y
         continue-on-error: true
 
   app_builder:
@@ -122,111 +40,24 @@ jobs:
     permissions:
       contents: write
       packages: write
+    env:
+      GITHUB_PAGE_COUNT: 30
+      NVD_START_YEAR: 2020
+      VDB_IGNORE_OS: true
+      VDB_METADATA_APP_ONLY: true
+      VDB_IGNORE_ALMALINUX: true
+      VDB_IGNORE_ALPINE: true
+      VDB_IGNORE_DEBIAN: true
+      VDB_IGNORE_ROCKYLINUX: true
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: ./.github/actions/setup-vdb
         with:
-          persist-credentials: false
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+          nvd-years: "nvd/2020\nnvd/2021\nnvd/2022\nnvd/2023\nnvd/2024\nnvd/2025\nnvd/2026"
+      - uses: ./.github/actions/build-upload-vdb
         with:
-          repository: AppThreat/vulnerability-db
-          path: vulnerability-db
-          ref: "master"
-          persist-credentials: false
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: AppThreat/vuln-list
-          path: vuln-list
-          fetch-depth: "1"
-          sparse-checkout: |
-            nvd/2020
-            nvd/2021
-            nvd/2022
-            nvd/2023
-            nvd/2024
-            nvd/2025
-            nvd/2026
-          persist-credentials: false
-      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Trim CI agent
-        run: |
-          chmod +x contrib/free_disk_space.sh
-          ./contrib/free_disk_space.sh
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine build
-          curl -LsSf https://hf.co/cli/install.sh | bash
-          hf --help
-          cd vulnerability-db && pip install -U ".[dev]"
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      - name: Build and upload app db - 2020
-        run: |
-          echo $GITHUB_TOKEN | oras login ghcr.io -u $GITHUB_USERNAME --password-stdin
-          mkdir vdb_data vdb_cache
-          ls ./vuln-list/ ./vuln-list/nvd/
-          zip -q -r vuln-list.zip ./vuln-list/
-          mv vuln-list.zip vdb_cache/
-          rm -rf ./vuln-list/
-          python vulnerability-db/vdb/cli.py --cache-os
-          ls -lh vdb_data
-          ls -lh vdb_cache
-          cd vdb_data
-          tar -cvJf data.vdb6.tar.xz data.vdb6
-          tar -cvJf data.index.vdb6.tar.xz data.index.vdb6
-          oras push ghcr.io/appthreat/vdbxz-app:v6.5.x \
-            --artifact-type application/vnd.oras.config.v1+json \
-            ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-            ./data.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
-            ./data.index.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
-          oras tag ghcr.io/appthreat/vdbxz-app:v6.5.x v6
-          hf upload --quiet --repo-type dataset --delete app/*.tar.xz AppThreat/vdb ./data.vdb6.tar.xz app/data.vdb6.tar.xz
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6.tar.xz app/data.index.vdb6.tar.xz
-          zstd --ultra data.index.vdb6
-          zstd --ultra data.vdb6
-          oras push ghcr.io/appthreat/vdbzst-app:v6.5.x \
-            --artifact-type application/vnd.oras.config.v1+json \
-            ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-            ./data.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst \
-            ./data.index.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst
-          oras tag ghcr.io/appthreat/vdbzst-app:v6.5.x v6
-          hf upload --quiet --repo-type dataset --delete app/*.zst AppThreat/vdb ./data.vdb6.zst app/data.vdb6.zst
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6.zst app/data.index.vdb6.zst
-          hf upload --quiet --repo-type dataset --delete app-2y/*.vdb6 AppThreat/vdb ./data.vdb6 app/data.vdb6
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6 app/data.index.vdb6
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./vdb.meta app/vdb.meta
-          # echo $CODEBERG_TOKEN | oras login codeberg.org -u $CODEBERG_USERNAME --password-stdin
-          # oras push codeberg.org/appthreat/vdbzst-app:v6.5.x \
-          #   --artifact-type application/vnd.oras.config.v1+json \
-          #   ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-          #   ./data.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst \
-          #   ./data.index.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst
-          # oras push codeberg.org/appthreat/vdbxz-app:v6.5.x \
-          #   --artifact-type application/vnd.oras.config.v1+json \
-          #   ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-          #   ./data.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
-          #   ./data.index.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODEBERG_TOKEN: ${{ secrets.CODEBERG_DEPLOY }}
-          PYTHONPATH: vulnerability-db
-          VDB_HOME: vdb_data
-          VDB_CACHE: vdb_cache
-          GITHUB_PAGE_COUNT: 30
-          NVD_START_YEAR: 2020
-          GITHUB_USERNAME: ${{ github.actor }}
-          CODEBERG_USERNAME: appthreat
-          VDB_METADATA_APP_ONLY: true
-          VDB_IGNORE_OS: true
-          VDB_IGNORE_ALMALINUX: true
-          VDB_IGNORE_ALPINE: true
-          VDB_IGNORE_DEBIAN: true
-          VDB_IGNORE_ROCKYLINUX: true
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          xz-image-name: vdbxz-app
+          zst-image-name: vdbzst-app
+          hf-path: app
         continue-on-error: true
 
   app_10y_builder:
@@ -234,115 +65,24 @@ jobs:
     permissions:
       contents: write
       packages: write
+    env:
+      GITHUB_PAGE_COUNT: 30
+      NVD_START_YEAR: 2020
+      VDB_IGNORE_OS: true
+      VDB_METADATA_APP_ONLY: true
+      VDB_IGNORE_ALMALINUX: true
+      VDB_IGNORE_ALPINE: true
+      VDB_IGNORE_DEBIAN: true
+      VDB_IGNORE_ROCKYLINUX: true
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: ./.github/actions/setup-vdb
         with:
-          persist-credentials: false
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+          nvd-years: "nvd/2016\nnvd/2017\nnvd/2018\nnvd/2019\nnvd/2020\nnvd/2021\nnvd/2022\nnvd/2023\nnvd/2024\nnvd/2025\nnvd/2026"
+      - uses: ./.github/actions/build-upload-vdb
         with:
-          repository: AppThreat/vulnerability-db
-          path: vulnerability-db
-          ref: "master"
-          persist-credentials: false
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: AppThreat/vuln-list
-          path: vuln-list
-          fetch-depth: "1"
-          sparse-checkout: |
-            nvd/2016
-            nvd/2017
-            nvd/2020
-            nvd/2019
-            nvd/2020
-            nvd/2021
-            nvd/2022
-            nvd/2023
-            nvd/2024
-            nvd/2025
-            nvd/2026
-          persist-credentials: false
-      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-        with:
-          python-version: "3.12"
-      - name: Trim CI agent
-        run: |
-          chmod +x contrib/free_disk_space.sh
-          ./contrib/free_disk_space.sh
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel twine build
-          curl -LsSf https://hf.co/cli/install.sh | bash
-          hf --help
-          cd vulnerability-db && pip install -U ".[dev]"
-        env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      - name: Build and upload app db - 2020
-        run: |
-          echo $GITHUB_TOKEN | oras login ghcr.io -u $GITHUB_USERNAME --password-stdin
-          mkdir vdb_data vdb_cache
-          ls ./vuln-list/ ./vuln-list/nvd/
-          zip -q -r vuln-list.zip ./vuln-list/
-          mv vuln-list.zip vdb_cache/
-          rm -rf ./vuln-list/
-          python vulnerability-db/vdb/cli.py --cache-os
-          ls -lh vdb_data
-          ls -lh vdb_cache
-          cd vdb_data
-          tar -cvJf data.vdb6.tar.xz data.vdb6
-          tar -cvJf data.index.vdb6.tar.xz data.index.vdb6
-          oras push ghcr.io/appthreat/vdbxz-app-10y:v6.5.x \
-            --artifact-type application/vnd.oras.config.v1+json \
-            ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-            ./data.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
-            ./data.index.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
-          oras tag ghcr.io/appthreat/vdbxz-app-10y:v6.5.x v6
-          hf upload --quiet --repo-type dataset --delete app-10y/*.tar.xz AppThreat/vdb ./data.vdb6.tar.xz app-10y/data.vdb6.tar.xz
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6.tar.xz app-10y/data.index.vdb6.tar.xz
-          zstd --ultra data.index.vdb6
-          zstd --ultra data.vdb6
-          oras push ghcr.io/appthreat/vdbzst-app-10y:v6.5.x \
-            --artifact-type application/vnd.oras.config.v1+json \
-            ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-            ./data.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst \
-            ./data.index.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst
-          oras tag ghcr.io/appthreat/vdbzst-app-10y:v6.5.x v6
-          hf upload --quiet --repo-type dataset --delete app-10y/*.zst AppThreat/vdb ./data.vdb6.zst app-10y/data.vdb6.zst
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6.zst app-10y/data.index.vdb6.zst
-          hf upload --quiet --repo-type dataset --delete app-10y/*.vdb6 AppThreat/vdb ./data.vdb6 app-10y/data.vdb6
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6 app-10y/data.index.vdb6
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./vdb.meta app-10y/vdb.meta
-          # echo $CODEBERG_TOKEN | oras login codeberg.org -u $CODEBERG_USERNAME --password-stdin
-          # oras push codeberg.org/appthreat/vdbzst-app-10y:v6.5.x \
-          #   --artifact-type application/vnd.oras.config.v1+json \
-          #   ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-          #   ./data.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst \
-          #   ./data.index.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst
-          # oras push codeberg.org/appthreat/vdbxz-app-10y:v6.5.x \
-          #   --artifact-type application/vnd.oras.config.v1+json \
-          #   ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-          #   ./data.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
-          #   ./data.index.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODEBERG_TOKEN: ${{ secrets.CODEBERG_DEPLOY }}
-          PYTHONPATH: vulnerability-db
-          VDB_HOME: vdb_data
-          VDB_CACHE: vdb_cache
-          GITHUB_PAGE_COUNT: 30
-          NVD_START_YEAR: 2020
-          GITHUB_USERNAME: ${{ github.actor }}
-          CODEBERG_USERNAME: appthreat
-          VDB_METADATA_APP_ONLY: true
-          VDB_IGNORE_OS: true
-          VDB_IGNORE_ALMALINUX: true
-          VDB_IGNORE_ALPINE: true
-          VDB_IGNORE_DEBIAN: true
-          VDB_IGNORE_ROCKYLINUX: true
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          xz-image-name: vdbxz-app-10y
+          zst-image-name: vdbzst-app-10y
+          hf-path: app-10y
         continue-on-error: true
 
   os_builder:
@@ -351,103 +91,36 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: ./.github/actions/setup-vdb
         with:
-          persist-credentials: false
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+          sparse-checkout: 'false'
+          self-hosted: 'true'
+      - uses: ./.github/actions/build-upload-vdb
         with:
-          repository: AppThreat/vulnerability-db
-          path: vulnerability-db
-          ref: "master"
-          persist-credentials: false
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: AppThreat/vuln-list
-          path: vuln-list
-          fetch-depth: "1"
-          persist-credentials: false
-      - uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3  # v2.0.0
-      - name: Install dependencies
-        run: |
-          python3 -m pip config set global.break-system-packages true
-          curl -LsSf https://hf.co/cli/install.sh | bash
-          hf --help
-          cd vulnerability-db && python3 -m pip install -U ".[dev]" --no-warn-script-location
+          xz-image-name: vdbxz
+          zst-image-name: vdbzst
+          hf-path: app-os
+          self-hosted: 'true'
+          os-exclude-dirs: 'kevc mariner cvrf/suse/suse'
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-      - name: Build and upload db - 2020
-        run: |
-          echo $GITHUB_TOKEN | oras login ghcr.io -u $GITHUB_USERNAME --password-stdin
-          mkdir vdb_data vdb_cache
-          rm -rf ./vuln-list/kevc ./vuln-list/mariner ./vuln-list/cvrf/suse/suse
-          zip -q -r vuln-list.zip ./vuln-list/
-          mv vuln-list.zip vdb_cache/
-          rm -rf ./vuln-list/
-          python3 vulnerability-db/vdb/cli.py --cache-os
-          ls -lh vdb_data
-          ls -lh vdb_cache
-          cd vdb_data
-          tar -cvJf data.vdb6.tar.xz data.vdb6
-          tar -cvJf data.index.vdb6.tar.xz data.index.vdb6
-          oras push ghcr.io/appthreat/vdbxz:v6.5.x \
-            --artifact-type application/vnd.oras.config.v1+json \
-            ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-            ./data.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
-            ./data.index.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
-          oras tag ghcr.io/appthreat/vdbxz:v6.5.x v6
-          hf upload --quiet --repo-type dataset --delete app-os/*.tar.xz AppThreat/vdb ./data.vdb6.tar.xz app-os/data.vdb6.tar.xz
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6.tar.xz app-os/data.index.vdb6.tar.xz
-          zstd --ultra data.index.vdb6
-          zstd --ultra data.vdb6
-          oras push ghcr.io/appthreat/vdbzst:v6.5.x \
-            --artifact-type application/vnd.oras.config.v1+json \
-            ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-            ./data.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst \
-            ./data.index.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst
-          oras tag ghcr.io/appthreat/vdbzst:v6.5.x v6
-          hf upload --quiet --repo-type dataset --delete app-os/*.zst AppThreat/vdb ./data.vdb6.zst app-os/data.vdb6.zst
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6.zst app-os/data.index.vdb6.zst
-          hf upload --quiet --repo-type dataset --delete app-os/*.vdb6 AppThreat/vdb ./data.vdb6 app-os/data.vdb6
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6 app-os/data.index.vdb6
-          hf upload --quiet --repo-type dataset AppThreat/vdb ./vdb.meta app-os/vdb.meta
-          # echo $CODEBERG_TOKEN | oras login codeberg.org -u $CODEBERG_USERNAME --password-stdin
-          # oras push codeberg.org/appthreat/vdbzst:v6.5.x \
-          #   --artifact-type application/vnd.oras.config.v1+json \
-          #   ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-          #   ./data.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst \
-          #   ./data.index.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst
-          # oras push codeberg.org/appthreat/vdbxz:v6.5.x \
-          #   --artifact-type application/vnd.oras.config.v1+json \
-          #   ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-          #   ./data.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
-          #   ./data.index.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODEBERG_TOKEN: ${{ secrets.CODEBERG_DEPLOY }}
-          PYTHONPATH: vulnerability-db
-          VDB_HOME: vdb_data
-          VDB_CACHE: vdb_cache
           GITHUB_PAGE_COUNT: 10
           NVD_START_YEAR: 2020
-          GITHUB_USERNAME: ${{ github.actor }}
-          CODEBERG_USERNAME: appthreat
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: AppThreat/vuln-list
-          path: vuln-list2
-          fetch-depth: "1"
+          path: vuln-list-10y
+          fetch-depth: '1'
           persist-credentials: false
-      - name: Build and upload db - 2016
+      - name: Build and upload VDB 10y
         run: |
           echo $GITHUB_TOKEN | oras login ghcr.io -u $GITHUB_USERNAME --password-stdin
           cd $GITHUB_WORKSPACE
           rm -rf vdb_data vdb_cache
           mkdir vdb_data vdb_cache
-          rm -rf ./vuln-list/kevc ./vuln-list/mariner ./vuln-list/cvrf/suse/suse
-          zip -q -r vuln-list.zip ./vuln-list2/
+          rm -rf ./vuln-list-10y/kevc ./vuln-list-10y/mariner ./vuln-list-10y/cvrf/suse/suse
+          zip -q -r vuln-list.zip ./vuln-list-10y/
           mv vuln-list.zip vdb_cache/
-          rm -rf ./vuln-list2/
+          rm -rf ./vuln-list-10y/
           python3 vulnerability-db/vdb/cli.py --cache-os
           ls -lh vdb_data
           ls -lh vdb_cache
@@ -475,25 +148,12 @@ jobs:
           hf upload --quiet --repo-type dataset --delete app-os-10y/*.vdb6 AppThreat/vdb ./data.vdb6 app-os-10y/data.vdb6
           hf upload --quiet --repo-type dataset AppThreat/vdb ./data.index.vdb6 app-os-10y/data.index.vdb6
           hf upload --quiet --repo-type dataset AppThreat/vdb ./vdb.meta app-os-10y/vdb.meta
-          # echo $CODEBERG_TOKEN | oras login codeberg.org -u $CODEBERG_USERNAME --password-stdin
-          # oras push codeberg.org/appthreat/vdbzst-10y:v6.5.x \
-          #   --artifact-type application/vnd.oras.config.v1+json \
-          #   ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-          #   ./data.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst \
-          #   ./data.index.vdb6.zst:application/vnd.appthreat.vdb.layer.v1+zst
-          # oras push codeberg.org/appthreat/vdbxz-10y:v6.5.x \
-          #   --artifact-type application/vnd.oras.config.v1+json \
-          #   ./vdb.meta:application/vnd.appthreat.vdb.config.v1+json \
-          #   ./data.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar \
-          #   ./data.index.vdb6.tar.xz:application/vnd.appthreat.vdb.layer.v1+tar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CODEBERG_TOKEN: ${{ secrets.CODEBERG_DEPLOY }}
           PYTHONPATH: vulnerability-db
           VDB_HOME: vdb_data
           VDB_CACHE: vdb_cache
           GITHUB_PAGE_COUNT: 20
           NVD_START_YEAR: 2016
           GITHUB_USERNAME: ${{ github.actor }}
-          CODEBERG_USERNAME: appthreat
           HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/build-vdb65.yml
+++ b/.github/workflows/build-vdb65.yml
@@ -24,6 +24,9 @@ jobs:
       VDB_IGNORE_ALPINE: true
       VDB_IGNORE_DEBIAN: true
       VDB_IGNORE_ROCKYLINUX: true
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      GITHUB_USERNAME: ${{ github.actor }}
     steps:
       - uses: ./.github/actions/setup-vdb
         with:
@@ -33,6 +36,9 @@ jobs:
           xz-image-name: vdbxz-app-2y
           zst-image-name: vdbzst-app-2y
           hf-path: app-2y
+          hf-token: ${{ secrets.HF_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-username: ${{ github.actor }}
         continue-on-error: true
 
   app_builder:
@@ -49,6 +55,9 @@ jobs:
       VDB_IGNORE_ALPINE: true
       VDB_IGNORE_DEBIAN: true
       VDB_IGNORE_ROCKYLINUX: true
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      GITHUB_USERNAME: ${{ github.actor }}
     steps:
       - uses: ./.github/actions/setup-vdb
         with:
@@ -58,6 +67,9 @@ jobs:
           xz-image-name: vdbxz-app
           zst-image-name: vdbzst-app
           hf-path: app
+          hf-token: ${{ secrets.HF_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-username: ${{ github.actor }}
         continue-on-error: true
 
   app_10y_builder:
@@ -74,6 +86,9 @@ jobs:
       VDB_IGNORE_ALPINE: true
       VDB_IGNORE_DEBIAN: true
       VDB_IGNORE_ROCKYLINUX: true
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      GITHUB_USERNAME: ${{ github.actor }}
     steps:
       - uses: ./.github/actions/setup-vdb
         with:
@@ -83,6 +98,9 @@ jobs:
           xz-image-name: vdbxz-app-10y
           zst-image-name: vdbzst-app-10y
           hf-path: app-10y
+          hf-token: ${{ secrets.HF_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-username: ${{ github.actor }}
         continue-on-error: true
 
   os_builder:
@@ -100,6 +118,9 @@ jobs:
           xz-image-name: vdbxz
           zst-image-name: vdbzst
           hf-path: app-os
+          hf-token: ${{ secrets.HF_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-username: ${{ github.actor }}
           self-hosted: 'true'
           os-exclude-dirs: 'kevc mariner cvrf/suse/suse'
         env:


### PR DESCRIPTION
Extract highly duplicated setup and build/upload logic into reusable composite actions, reducing 499-line workflow to 159 lines.

- Add setup-vdb action: consolidated repo checkout, tool setup, dependency install
- Add build-upload-vdb action: consolidated build, compress (xz/zstd), ORAS push, and HuggingFace upload pipeline
- Fix: duplicate nvd/2020 entry in app_10y_builder sparse-checkout
- Fix: missing nvd/2018 in app_10y_builder sparse-checkout
- Fix: app_builder HF uploads went to wrong app-2y/ path instead of app/
- Remove dead commented Codeberg push commands from all jobs
- Job-level env vars for VDB_IGNORE_* and build parameters